### PR TITLE
bugfix-changed mapbox link to https

### DIFF
--- a/app/scripts/my-map.js
+++ b/app/scripts/my-map.js
@@ -2,9 +2,9 @@
 
     L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ', {
       maxZoom: 18,
-      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-        '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-        'Imagery © <a href="http://mapbox.com">Mapbox</a>',
+      attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+        '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+        'Imagery © <a href="https://mapbox.com">Mapbox</a>',
       id: 'mapbox.streets'
     }).addTo(map);
 


### PR DESCRIPTION
Our app wasn't loading the mapbox tiles. I just switched the links from http to https. Should work now. Please push to heroku. 
